### PR TITLE
Update plugin.yml

### DIFF
--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -7,4 +7,4 @@ website: https://github.com/Sfiguz7/ExtraTools
 main: me.sfiguz7.extratools.ExtraTools
 depend: [Slimefun]
 
-api-version: 1.14
+api-version: 1.18


### PR DESCRIPTION
changing required version from 1.14 to 1.18 as you already have spigot 1.18+ as a dependency. you also have Deepslate ores added to Hammer.java so at the very least it should be changed from 1.14 to 1.17